### PR TITLE
[review-mirror] Fix runner APPLICATION_HANG_QUIESCE: handle WM_ENDSESSION and skip blocking shutdown cleanup

### DIFF
--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -231,6 +231,9 @@ namespace UnitTestsCommonUtils
 
             // After DestroyWindow the window must no longer exist and the
             // message loop must exit promptly because WM_QUIT was posted.
+            // The timeout was 1000 ms; assert well under that (2000 ms gives
+            // headroom for slow CI VMs while still failing if the loop is
+            // actually waiting out the full timeout).
             auto start = std::chrono::steady_clock::now();
             run_message_loop(false, 1000);
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -238,7 +241,7 @@ namespace UnitTestsCommonUtils
 
             Assert::IsFalse(IsWindow(hwnd) == TRUE,
                             L"Window must be destroyed after WM_ENDSESSION(TRUE)");
-            Assert::IsTrue(elapsed.count() < 500,
+            Assert::IsTrue(elapsed.count() < 2000,
                            L"Message loop must exit quickly after WM_ENDSESSION, not wait for the timeout");
 
             UnregisterClassW(L"EndSessionTest_Confirmed", GetModuleHandleW(nullptr));

--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -155,5 +155,103 @@ namespace UnitTestsCommonUtils
 
             Assert::IsTrue(true);
         }
+
+        // handle_session_end_message tests
+        //
+        // These guard the fix for APPLICATION_HANG_QUIESCE in
+        // PowerToys.exe!run_message_loop, where the runner and most modules
+        // failed to handle WM_QUERYENDSESSION / WM_ENDSESSION and were
+        // force-terminated on every OS shutdown, sign-out, or restart.
+        TEST_METHOD(HandleSessionEndMessage_QueryEndSession_AllowsShutdown)
+        {
+            LRESULT result = 0;
+            bool handled = handle_session_end_message(nullptr, WM_QUERYENDSESSION, 0, result);
+
+            Assert::IsTrue(handled, L"WM_QUERYENDSESSION should be handled");
+            Assert::AreEqual(static_cast<LRESULT>(TRUE), result,
+                             L"WM_QUERYENDSESSION must return TRUE so the OS can proceed with shutdown");
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_EndSessionCancelled_DoesNotTearDown)
+        {
+            // wparam == FALSE means another app vetoed shutdown; we must not
+            // tear down. We pass a real HWND so that an accidental
+            // DestroyWindow call would be observable.
+            WNDCLASSW wc{};
+            wc.lpfnWndProc = DefWindowProcW;
+            wc.hInstance = GetModuleHandleW(nullptr);
+            wc.lpszClassName = L"EndSessionTest_Cancelled";
+            RegisterClassW(&wc);
+
+            HWND hwnd = CreateWindowExW(0, L"EndSessionTest_Cancelled", L"Test",
+                                        0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                        GetModuleHandleW(nullptr), nullptr);
+            Assert::IsNotNull(hwnd, L"Test window must be created");
+
+            LRESULT result = 0xDEAD;
+            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, FALSE, result);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::AreEqual(static_cast<LRESULT>(0), result);
+            Assert::IsTrue(IsWindow(hwnd) == TRUE,
+                           L"Window must survive WM_ENDSESSION when shutdown is cancelled");
+
+            DestroyWindow(hwnd);
+            UnregisterClassW(L"EndSessionTest_Cancelled", GetModuleHandleW(nullptr));
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_EndSessionConfirmed_TearsDownAndExitsLoop)
+        {
+            // wparam == TRUE means shutdown is actually proceeding. The
+            // helper must DestroyWindow, which routes through WM_DESTROY ->
+            // PostQuitMessage(0), so a subsequent run_message_loop returns.
+            WNDCLASSW wc{};
+            wc.lpfnWndProc = [](HWND hwnd, UINT msg, WPARAM w, LPARAM l) -> LRESULT {
+                if (msg == WM_DESTROY)
+                {
+                    PostQuitMessage(0);
+                    return 0;
+                }
+                return DefWindowProcW(hwnd, msg, w, l);
+            };
+            wc.hInstance = GetModuleHandleW(nullptr);
+            wc.lpszClassName = L"EndSessionTest_Confirmed";
+            RegisterClassW(&wc);
+
+            HWND hwnd = CreateWindowExW(0, L"EndSessionTest_Confirmed", L"Test",
+                                        0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                        GetModuleHandleW(nullptr), nullptr);
+            Assert::IsNotNull(hwnd, L"Test window must be created");
+
+            LRESULT result = 0xDEAD;
+            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, TRUE, result);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::AreEqual(static_cast<LRESULT>(0), result);
+
+            // After DestroyWindow the window must no longer exist and the
+            // message loop must exit promptly because WM_QUIT was posted.
+            auto start = std::chrono::steady_clock::now();
+            run_message_loop(false, 1000);
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - start);
+
+            Assert::IsFalse(IsWindow(hwnd) == TRUE,
+                            L"Window must be destroyed after WM_ENDSESSION(TRUE)");
+            Assert::IsTrue(elapsed.count() < 500,
+                           L"Message loop must exit quickly after WM_ENDSESSION, not wait for the timeout");
+
+            UnregisterClassW(L"EndSessionTest_Confirmed", GetModuleHandleW(nullptr));
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_UnrelatedMessage_NotHandled)
+        {
+            LRESULT result = 0xDEAD;
+            bool handled = handle_session_end_message(nullptr, WM_USER, 0, result);
+
+            Assert::IsFalse(handled, L"Non-end-session messages must fall through");
+            Assert::AreEqual(static_cast<LRESULT>(0xDEAD), result,
+                             L"out_result must be left untouched when not handled");
+        }
     };
 }

--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -253,5 +253,72 @@ namespace UnitTestsCommonUtils
             Assert::AreEqual(static_cast<LRESULT>(0xDEAD), result,
                              L"out_result must be left untouched when not handled");
         }
+
+        // out_session_ending tests
+        //
+        // The optional out-param lets a caller's WM_DESTROY skip blocking
+        // cross-process cleanup (the 1.5s wait on PowerToys.Settings.exe in the
+        // runner) only on a real OS-initiated shutdown, which is what keeps the
+        // teardown inside the quiesce budget.
+        TEST_METHOD(HandleSessionEndMessage_EndSessionConfirmed_SignalsSessionEnding)
+        {
+            // wparam == TRUE must flag session-ending before tearing the window down.
+            WNDCLASSW wc{};
+            wc.lpfnWndProc = [](HWND hwnd, UINT msg, WPARAM w, LPARAM l) -> LRESULT {
+                if (msg == WM_DESTROY)
+                {
+                    PostQuitMessage(0);
+                    return 0;
+                }
+                return DefWindowProcW(hwnd, msg, w, l);
+            };
+            wc.hInstance = GetModuleHandleW(nullptr);
+            wc.lpszClassName = L"EndSessionTest_Signals";
+            RegisterClassW(&wc);
+
+            HWND hwnd = CreateWindowExW(0, L"EndSessionTest_Signals", L"Test",
+                                        0, 0, 0, 0, 0, HWND_MESSAGE, nullptr,
+                                        GetModuleHandleW(nullptr), nullptr);
+            Assert::IsNotNull(hwnd, L"Test window must be created");
+
+            LRESULT result = 0;
+            bool session_ending = false;
+            bool handled = handle_session_end_message(hwnd, WM_ENDSESSION, TRUE, result, &session_ending);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::IsTrue(session_ending,
+                           L"WM_ENDSESSION(TRUE) must flag session-ending so WM_DESTROY can skip blocking cleanup");
+
+            // Drain the WM_QUIT posted by the test WndProc so it cannot leak into
+            // a subsequent test running on the same thread.
+            run_message_loop(false, 1000);
+            UnregisterClassW(L"EndSessionTest_Signals", GetModuleHandleW(nullptr));
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_EndSessionCancelled_DoesNotSignalSessionEnding)
+        {
+            // wparam == FALSE (another app vetoed) must not flag session-ending, so a
+            // caller keeps doing its normal cleanup if it later closes on its own.
+            LRESULT result = 0;
+            bool session_ending = false;
+            bool handled = handle_session_end_message(nullptr, WM_ENDSESSION, FALSE, result, &session_ending);
+
+            Assert::IsTrue(handled, L"WM_ENDSESSION should be handled");
+            Assert::IsFalse(session_ending,
+                            L"A cancelled shutdown must not flag session-ending");
+        }
+
+        TEST_METHOD(HandleSessionEndMessage_QueryEndSession_DoesNotSignalSessionEnding)
+        {
+            // The query phase only asks permission; it must not flag teardown.
+            LRESULT result = 0;
+            bool session_ending = false;
+            bool handled = handle_session_end_message(nullptr, WM_QUERYENDSESSION, 0, result, &session_ending);
+
+            Assert::IsTrue(handled, L"WM_QUERYENDSESSION should be handled");
+            Assert::AreEqual(static_cast<LRESULT>(TRUE), result);
+            Assert::IsFalse(session_ending,
+                            L"WM_QUERYENDSESSION must not flag session-ending");
+        }
     };
 }

--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -231,9 +231,8 @@ namespace UnitTestsCommonUtils
 
             // After DestroyWindow the window must no longer exist and the
             // message loop must exit promptly because WM_QUIT was posted.
-            // The timeout was 1000 ms; assert well under that (2000 ms gives
-            // headroom for slow CI VMs while still failing if the loop is
-            // actually waiting out the full timeout).
+            // The timeout is 1000 ms. Allow headroom for slow CI VMs while
+            // still failing if the loop waits out the full timeout.
             auto start = std::chrono::steady_clock::now();
             run_message_loop(false, 1000);
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/common/UnitTests-CommonUtils/Window.Tests.cpp
+++ b/src/common/UnitTests-CommonUtils/Window.Tests.cpp
@@ -231,8 +231,8 @@ namespace UnitTestsCommonUtils
 
             // After DestroyWindow the window must no longer exist and the
             // message loop must exit promptly because WM_QUIT was posted.
-            // The timeout is 1000 ms. Allow headroom for slow CI VMs while
-            // still failing if the loop waits out the full timeout.
+            // The timeout is 1000 ms; require the loop to exit well before
+            // that so the test catches regressions that wait for the timer.
             auto start = std::chrono::steady_clock::now();
             run_message_loop(false, 1000);
             auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -240,7 +240,7 @@ namespace UnitTestsCommonUtils
 
             Assert::IsFalse(IsWindow(hwnd) == TRUE,
                             L"Window must be destroyed after WM_ENDSESSION(TRUE)");
-            Assert::IsTrue(elapsed.count() < 2000,
+            Assert::IsTrue(elapsed.count() < 500,
                            L"Message loop must exit quickly after WM_ENDSESSION, not wait for the timeout");
 
             UnregisterClassW(L"EndSessionTest_Confirmed", GetModuleHandleW(nullptr));

--- a/src/common/utils/window.h
+++ b/src/common/utils/window.h
@@ -41,6 +41,42 @@ inline int run_message_loop(const bool until_idle = false,
     return static_cast<int>(msg.wParam);
 }
 
+// Handles WM_QUERYENDSESSION / WM_ENDSESSION for processes that have no
+// unsaved user state of their own (the PowerToys runner and most modules).
+//
+// WndProcs should call this at the top of their dispatch and return early
+// when it reports the message was handled. Without this, the OS quiesce
+// handshake on shutdown / sign-out / restart / suspend has nothing to wait
+// on except the full timeout, producing APPLICATION_HANG_QUIESCE failure
+// buckets even though the process is idle in GetMessage.
+//
+// On WM_QUERYENDSESSION we always allow the session to end (returns TRUE).
+// On WM_ENDSESSION with wparam == TRUE we DestroyWindow(window), which then
+// drives the existing WM_DESTROY -> PostQuitMessage(0) path and lets
+// run_message_loop unwind cleanly. wparam == FALSE means the session was
+// cancelled by another application's WM_QUERYENDSESSION response, in which
+// case we must not tear down.
+//
+// Returns true if the message was an end-session message and out_result has
+// been set; the caller should return out_result without further dispatch.
+inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam, LRESULT& out_result)
+{
+    switch (message)
+    {
+    case WM_QUERYENDSESSION:
+        out_result = TRUE;
+        return true;
+    case WM_ENDSESSION:
+        if (wparam)
+        {
+            DestroyWindow(window);
+        }
+        out_result = 0;
+        return true;
+    }
+    return false;
+}
+
 // Check if window is part of the shell or the taskbar.
 inline bool is_system_window(HWND hwnd, const char* class_name)
 {

--- a/src/common/utils/window.h
+++ b/src/common/utils/window.h
@@ -59,7 +59,14 @@ inline int run_message_loop(const bool until_idle = false,
 //
 // Returns true if the message was an end-session message and out_result has
 // been set; the caller should return out_result without further dispatch.
-inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam, LRESULT& out_result)
+//
+// When out_session_ending is non-null it is set to true exactly when an actual
+// teardown begins (WM_ENDSESSION with wparam == TRUE) and is left untouched
+// otherwise. Callers whose WM_DESTROY performs blocking cross-process cleanup
+// (for example waiting on a child process) can read this flag and skip that
+// work on OS shutdown, where the OS is already reaping those processes in
+// parallel and the quiesce budget is too short to wait on them.
+inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam, LRESULT& out_result, bool* out_session_ending = nullptr)
 {
     switch (message)
     {
@@ -69,6 +76,10 @@ inline bool handle_session_end_message(HWND window, UINT message, WPARAM wparam,
     case WM_ENDSESSION:
         if (wparam)
         {
+            if (out_session_ending)
+            {
+                *out_session_ending = true;
+            }
             DestroyWindow(window);
         }
         out_result = 0;

--- a/src/common/utils/window.h
+++ b/src/common/utils/window.h
@@ -46,7 +46,7 @@ inline int run_message_loop(const bool until_idle = false,
 //
 // WndProcs should call this at the top of their dispatch and return early
 // when it reports the message was handled. Without this, the OS quiesce
-// handshake on shutdown / sign-out / restart / suspend has nothing to wait
+// handshake on shutdown / sign-out / restart has nothing to wait
 // on except the full timeout, producing APPLICATION_HANG_QUIESCE failure
 // buckets even though the process is idle in GetMessage.
 //

--- a/src/runner/main.cpp
+++ b/src/runner/main.cpp
@@ -352,7 +352,15 @@ int runner(bool isProcessElevated, bool openSettings, std::string settingsWindow
         result = -1;
     }
     Trace::UnregisterProvider();
-    QuickAccessHost::stop();
+    // On OS-initiated shutdown the OS reaps the Quick Access host process in
+    // parallel, so blocking up to the QuickAccessHost::stop() wait timeout here
+    // is pure dead time against the quiesce budget. Skip when the runner
+    // observed WM_ENDSESSION(TRUE); the user-initiated tray->Exit path still
+    // calls stop() and unwinds cleanly.
+    if (!is_session_ending())
+    {
+        QuickAccessHost::stop();
+    }
     return result;
 }
 

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -563,6 +563,11 @@ void stop_tray_icon()
         SendMessage(tray_icon_hwnd, WM_CLOSE, 0, 0);
     }
 }
+
+bool is_session_ending()
+{
+    return g_session_ending;
+}
 void update_quick_access_hotkey(bool enabled, PowerToysSettings::HotkeyObject hotkey)
 {
     static PowerToysSettings::HotkeyObject current_hotkey;

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -36,6 +36,11 @@ namespace
     NOTIFYICONDATAW tray_icon_data;
     bool tray_icon_created = false;
 
+    // Set once the OS confirms session end (WM_ENDSESSION, wparam == TRUE) so the
+    // WM_DESTROY handler below can skip cross-process cleanup the OS is already
+    // reaping in parallel.
+    bool g_session_ending = false;
+
     bool about_box_shown = false;
 
     HMENU h_menu = nullptr;
@@ -157,7 +162,7 @@ void click_timer_elapsed()
 LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam)
 {
     LRESULT session_end_result = 0;
-    if (handle_session_end_message(window, message, wparam, session_end_result))
+    if (handle_session_end_message(window, message, wparam, session_end_result, &g_session_ending))
     {
         return session_end_result;
     }
@@ -181,12 +186,23 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
         }
         break;
     case WM_DESTROY:
-        if (tray_icon_created)
+        // On OS-initiated shutdown skip cross-process cleanup: the shell is tearing
+        // down and close_settings_window() blocks up to 1.5s waiting on
+        // PowerToys.Settings.exe, which the OS is reaping in parallel. That wait, plus
+        // Shell_NotifyIcon during explorer teardown, would burn the limited quiesce
+        // budget and trip APPLICATION_HANG_QUIESCE. PostQuitMessage alone unwinds the
+        // loop in milliseconds. User-initiated Exit (session_ending == false) keeps the
+        // full graceful cleanup.
+        Logger::info(L"Runner WM_DESTROY, session_ending={}", g_session_ending);
+        if (!g_session_ending)
         {
-            Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
-            tray_icon_created = false;
+            if (tray_icon_created)
+            {
+                Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
+                tray_icon_created = false;
+            }
+            close_settings_window();
         }
-        close_settings_window();
         PostQuitMessage(0);
         break;
     case WM_CLOSE:

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -11,6 +11,7 @@
 #include <Windows.h>
 
 #include <common/utils/resources.h>
+#include <common/utils/window.h>
 #include <common/version/version.h>
 #include <common/logger/logger.h>
 #include <common/utils/elevation.h>
@@ -155,6 +156,12 @@ void click_timer_elapsed()
 
 LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam, LPARAM lparam)
 {
+    LRESULT session_end_result = 0;
+    if (handle_session_end_message(window, message, wparam, session_end_result))
+    {
+        return session_end_result;
+    }
+
     switch (message)
     {
     case WM_HOTKEY:

--- a/src/runner/tray_icon.cpp
+++ b/src/runner/tray_icon.cpp
@@ -199,10 +199,11 @@ LRESULT __stdcall tray_icon_window_proc(HWND window, UINT message, WPARAM wparam
             if (tray_icon_created)
             {
                 Shell_NotifyIcon(NIM_DELETE, &tray_icon_data);
-                tray_icon_created = false;
             }
             close_settings_window();
         }
+        tray_icon_created = false;
+        tray_icon_hwnd = NULL;
         PostQuitMessage(0);
         break;
     case WM_CLOSE:

--- a/src/runner/tray_icon.h
+++ b/src/runner/tray_icon.h
@@ -13,6 +13,10 @@ void set_tray_icon_theme_adaptive(bool theme_adaptive);
 void set_tray_icon_update_available(bool available);
 // Stop the Tray Icon
 void stop_tray_icon();
+// True after the runner observed an OS-confirmed WM_ENDSESSION (wparam == TRUE).
+// Callers can use this to skip blocking cross-process cleanup the OS is already
+// reaping in parallel during shutdown / sign-off / restart.
+bool is_session_ending();
 // Open the Settings Window
 void open_settings_window(std::optional<std::wstring> settings_window);
 // Update Quick Access Hotkey

--- a/src/runner/tray_icon.h
+++ b/src/runner/tray_icon.h
@@ -15,7 +15,7 @@ void set_tray_icon_update_available(bool available);
 void stop_tray_icon();
 // True after the runner observed an OS-confirmed WM_ENDSESSION (wparam == TRUE).
 // Callers can use this to skip blocking cross-process cleanup the OS is already
-// reaping in parallel during shutdown / sign-off / restart.
+// reaping in parallel during shutdown / sign-out / restart.
 bool is_session_ending();
 // Open the Settings Window
 void open_settings_window(std::optional<std::wstring> settings_window);


### PR DESCRIPTION
Review sandbox mirror of microsoft/PowerToys#48363 (branch `user/crutkas/fix-runner-quiesce-hang`).

Opened by PR-autopilot to run Copilot Code Review + local build validation in the fork. Not for merge.