### PR TITLE
[review-mirror] microsoft/PowerToys#48404

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -238,6 +238,7 @@ closesocket
 clp
 CLSCTX
 CLSIDs
+CLOSEAPP
 clsids
 Clusion
 cmder

--- a/src/modules/GrabAndMove/GrabAndMove/main.cpp
+++ b/src/modules/GrabAndMove/GrabAndMove/main.cpp
@@ -27,6 +27,7 @@ static ULONG_PTR g_gdiplusToken = 0; // GDI+ token for overlay border rendering
 static HHOOK g_hhkKeyboard = nullptr;
 static HHOOK g_hhkMouse = nullptr;
 static HWND g_hMsgWnd = nullptr;
+static bool g_systemSessionEnding = false;
 
 // 0 = Alt (default), 1 = Win
 enum class GrabAndMoveModifier
@@ -1740,8 +1741,30 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         return 0;
 
     case WM_DESTROY:
-        RemoveTrayIcon();
+        if (!g_systemSessionEnding)
+        {
+            RemoveTrayIcon();
+        }
         PostQuitMessage(0);
+        return 0;
+    }
+
+    return DefWindowProcW(hwnd, msg, wParam, lParam);
+}
+
+static LRESULT CALLBACK OverlayWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg)
+    {
+    case WM_QUERYENDSESSION:
+        return TRUE;
+
+    case WM_ENDSESSION:
+        if (wParam)
+        {
+            g_systemSessionEnding = !(lParam & ENDSESSION_CLOSEAPP);
+            PostQuitMessage(0);
+        }
         return 0;
     }
 
@@ -1821,7 +1844,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
     // Register the overlay window class (layered per-pixel-alpha surface, ARROW cursor)
     WNDCLASSEXW overlayWindowClass = {};
     overlayWindowClass.cbSize = sizeof(overlayWindowClass);
-    overlayWindowClass.lpfnWndProc = DefWindowProcW;
+    overlayWindowClass.lpfnWndProc = OverlayWndProc;
     overlayWindowClass.hInstance = hInstance;
     overlayWindowClass.hCursor = LoadCursorW(nullptr, IDC_ARROW);
     overlayWindowClass.hbrBackground = nullptr; // per-pixel alpha via UpdateLayeredWindow
@@ -1836,6 +1859,16 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
     g_hMsgWnd = CreateWindowExW(0, CLASS_NAME, APP_TITLE, 0, 0, 0, 0, 0, HWND_MESSAGE, nullptr, hInstance, nullptr);
     if (!g_hMsgWnd)
     {
+        TraceLoggingUnregister(g_hProvider);
+        return 1;
+    }
+
+    // The message-only window does not receive session-end broadcasts. Keep a
+    // hidden top-level overlay window so the process can exit its message loop.
+    EnsureOverlayWindow();
+    if (!g_hOverlay)
+    {
+        DestroyWindow(g_hMsgWnd);
         TraceLoggingUnregister(g_hProvider);
         return 1;
     }
@@ -1912,7 +1945,10 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
         DestroyWindow(g_hOverlay);
         g_hOverlay = nullptr;
     }
-    RemoveTrayIcon();
+    if (!g_systemSessionEnding)
+    {
+        RemoveTrayIcon();
+    }
     if (g_gdiplusToken)
     {
         Gdiplus::GdiplusShutdown(g_gdiplusToken);

--- a/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
+++ b/src/modules/alwaysontop/AlwaysOnTop/AlwaysOnTop.cpp
@@ -211,7 +211,21 @@ void AlwaysOnTop::SettingsUpdate(SettingId id)
 
 LRESULT AlwaysOnTop::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lparam) noexcept
 {
-    if (message == WM_HOTKEY)
+    if (message == WM_QUERYENDSESSION)
+    {
+        return TRUE;
+    }
+    else if (message == WM_ENDSESSION)
+    {
+        if (wparam)
+        {
+            // This window has no WM_DESTROY -> PostQuitMessage path, so it
+            // cannot use handle_stateless_session_end_message.
+            PostQuitMessage(0);
+        }
+        return 0;
+    }
+    else if (message == WM_HOTKEY)
     {
         int hotkeyId = static_cast<int>(wparam);
         if (HWND fw{ GetForegroundWindow() })

--- a/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
+++ b/src/modules/fancyzones/FancyZonesLib/FancyZones.cpp
@@ -596,6 +596,18 @@ LRESULT FancyZones::WndProc(HWND window, UINT message, WPARAM wparam, LPARAM lpa
 {
     switch (message)
     {
+    case WM_QUERYENDSESSION:
+        return TRUE;
+
+    case WM_ENDSESSION:
+        if (wparam)
+        {
+            // This window has no WM_DESTROY -> PostQuitMessage path, so it
+            // cannot use handle_stateless_session_end_message.
+            PostQuitMessage(0);
+        }
+        return 0;
+
     case WM_HOTKEY:
     {
         if (wparam == static_cast<WPARAM>(HotkeyId::Editor))


### PR DESCRIPTION
## Summary
Modernizes the mirror of microsoft/PowerToys#48404 on current `origin/main` (`e141d172c8`), after merged microsoft/PowerToys#48363. Addresses microsoft/PowerToys#49539 for Grab and Move, Always On Top, and FancyZones only.

## Session-end behavior
- `WM_QUERYENDSESSION` returns `TRUE`.
- `WM_ENDSESSION(FALSE)` leaves each module running.
- `WM_ENDSESSION(TRUE)` posts `WM_QUIT` so the existing message loop unwinds promptly.
- Grab and Move creates its hidden top-level overlay at startup because its normal control window is message-only and does not receive session-end broadcasts.
- Grab and Move skips tray deletion only for a full system session end. `ENDSESSION_CLOSEAPP` retains normal cleanup.

## Shared helper assessment
`handle_stateless_session_end_message` from #48363 is intentionally not called by these modules. It destroys its window and relies on an existing `WM_DESTROY -> PostQuitMessage` path; these three window procedures do not provide that path. Their module-specific handlers preserve cancellation semantics and post `WM_QUIT` directly. There is no blocking work or logging in the shutdown dispatch path.

## Validation
- `tools\\build\\build-essentials.ps1 -Platform x64 -Configuration Debug` (restore + essentials): PASS
- GrabAndMove, AlwaysOnTop, FancyZonesLib targeted Debug|x64 builds via `tools\\build\\build.ps1`: PASS
- Common.Utils session-end helper tests via `vstest.console.exe`: 7/7 PASS

## Manual shutdown checklist
- [ ] With each module enabled, restart, sign out, and shut down Windows; confirm prompt exit and no `APPLICATION_HANG_QUIESCE` event.
- [ ] Send/cancel a shutdown request and confirm `WM_ENDSESSION(FALSE)` leaves each module usable.
- [ ] Trigger Restart Manager `ENDSESSION_CLOSEAPP` for Grab and Move and confirm normal tray cleanup; verify full shutdown avoids tray IPC.
- [ ] Start Grab and Move without a drag/resize, then shut down; confirm the eagerly created hidden top-level overlay receives the session-end handshake.