### PR TITLE
Fix latent check-spelling debt in main (typos, forbidden patterns, dictionary)

### DIFF
--- a/.github/actions/spell-check/expect.txt
+++ b/.github/actions/spell-check/expect.txt
@@ -136,8 +136,8 @@ BITMAPINFO
 BITMAPINFOHEADER
 BITSPERPEL
 BITSPIXEL
-Blackmagic
 bla
+Blackmagic
 BLENDFUNCTION
 blittable
 Blockquotes
@@ -174,6 +174,7 @@ BUNDLEINFO
 byapp
 BYCOMMAND
 BYPOSITION
+CABAC
 CALCRECT
 CALG
 callbackptr
@@ -400,8 +401,8 @@ devmgmt
 DEVMODE
 DEVMODEW
 DEVNODES
-devpal
 devpackages
+devpal
 DEVTYP
 dfx
 DIALOGEX
@@ -490,6 +491,7 @@ ENABLETAB
 ENABLETEMPLATE
 encodedlaunch
 encryptor
+endgroup
 ENDSESSION
 ENSUREVISIBLE
 ENTERSIZEMOVE
@@ -539,9 +541,9 @@ extensionsdk
 EXTRALIGHT
 EXTRINSICPROPERTIES
 eyetracker
+Fairlight
 FANCYZONESDRAWLAYOUTTEST
 FANCYZONESEDITOR
-Fairlight
 FARPROC
 fdw
 fdx
@@ -585,11 +587,13 @@ folderpath
 FONTTYPE
 FORCEFILESYSTEM
 FORCEMINIMIZE
+foregrounding
 FORMATDLGORD
 formatetc
 FORPARSING
 foundrylocal
 framechanged
+Freelook
 frm
 FROMTOUCH
 fsanitize
@@ -744,9 +748,17 @@ HROW
 hsb
 HSCROLL
 hsi
+HTBOTTOM
+HTBOTTOMLEFT
 HTCLIENT
 hthumbnail
+HTLEFT
+HTNOWHERE
 HTOUCHINPUT
+HTRIGHT
+HTTOP
+HTTOPLEFT
+HTTOPRIGHT
 HTTRANSPARENT
 hutchinsoniana
 Hvci
@@ -767,6 +779,7 @@ ICONLOCATION
 ICONONLY
 IDCANCEL
 IDD
+idempotently
 idk
 idl
 idlist
@@ -786,6 +799,7 @@ iid
 IIM
 Iindex
 Ijwhost
+ILC
 ILD
 IMAGEHLP
 IMAGERESIZERCONTEXTMENU
@@ -901,6 +915,7 @@ Kybd
 LARGEICON
 lastcodeanalysissucceeded
 LASTEXITCODE
+launchgame
 LAYOUTRTL
 lbl
 Lbuttondown
@@ -917,6 +932,7 @@ LEFTSCROLLBAR
 LEFTTEXT
 Lenovo
 LError
+letterboxing
 LEVELID
 LFU
 LGD
@@ -947,6 +963,7 @@ LOCALSYSTEM
 LOCATIONCHANGE
 LOCKTYPE
 LOGFONTW
+logissue
 LOGMSG
 logon
 LOGPIXELSX
@@ -1062,6 +1079,7 @@ MINIMIZESTART
 MINMAXINFO
 minwindef
 Mip
+Miracast
 mkdn
 mlcfg
 mmc
@@ -1100,6 +1118,7 @@ msctls
 msdata
 msdia
 MSDL
+msgamelaunch
 MSGFLT
 msiexec
 MSIFASTINSTALL
@@ -1196,6 +1215,7 @@ NODRAWICON
 NOINHERITLAYOUT
 NOINTERFACE
 NOINVERT
+nojekyll
 NOLINKINFO
 nologo
 NOMCX
@@ -1269,6 +1289,7 @@ oldpath
 oldtheme
 oleaut
 OLECHAR
+olk
 ollama
 onebranch
 onnx
@@ -1330,8 +1351,8 @@ pchast
 PCIDLIST
 PCTSTR
 PCWSTR
-pdbs
 PDBs
+pdbs
 PDEVMODE
 PDFs
 pdisp
@@ -1369,6 +1390,7 @@ pinfo
 pinvoke
 pipename
 Pitjantjatjara
+PJT
 PKBDLLHOOKSTRUCT
 pkgfamily
 PKI
@@ -1476,6 +1498,7 @@ ptc
 PTCHAR
 ptcontrols
 ptd
+PTLONGPATH
 PTOKEN
 ptstr
 ptsym
@@ -1562,6 +1585,7 @@ resizers
 RESIZETOFIT
 resmimetype
 RESOURCEID
+respawns
 RESTORETOMAXIMIZED
 RETURNONLYFSDIRS
 Revalidates
@@ -1572,6 +1596,7 @@ rgf
 rgh
 rgn
 rgs
+rgt
 rguid
 rhk
 RIDEV
@@ -1632,12 +1657,14 @@ selfhost
 SENDCHANGE
 sendvirtualinput
 serverside
+SETAUTOHIDEBAREX
 SETBUDDYINT
 SETCONTEXT
 SETCURSEL
 setcursor
 SETFOCUS
 SETFOREGROUND
+SETFOREGROUNDLOCKTIMEOUT
 SETHOTKEY
 SETICON
 SETLOWPOWERACTIVE
@@ -1645,7 +1672,6 @@ SETPOWEROFFACTIVE
 SETRANGE
 SETREDRAW
 SETRULES
-SETAUTOHIDEBAREX
 SETSCREENSAVEACTIVE
 SETSTICKYKEYS
 SETTEXT
@@ -1881,6 +1907,7 @@ TEXTBOXNEWLINE
 textextractor
 TEXTINCLUDE
 textvariable
+tfm
 tfopen
 tgamma
 tgz
@@ -1895,6 +1922,7 @@ TILEDWINDOW
 TILLSON
 timedate
 timediff
+timestamped
 timeutil
 TITLEBARINFO
 Titlecase
@@ -1957,6 +1985,7 @@ ULONGLONG
 Ultrawide
 ums
 uncompilable
+uncomposited
 UNCPRIORITY
 UNDNAME
 ungroup
@@ -2061,6 +2090,7 @@ Vtbl
 WANTNUKEWARNING
 WANTPALM
 WASDK
+watsonportal
 wbem
 Wca
 WCE

--- a/src/common/UITestAutomation/ModuleInfo.cs
+++ b/src/common/UITestAutomation/ModuleInfo.cs
@@ -31,7 +31,7 @@ namespace Microsoft.PowerToys.UITest
         /// the exe. This adapts to any build-output nesting — the local flattened
         /// <c>&lt;root&gt;\&lt;plat&gt;\&lt;cfg&gt;\tests\&lt;project&gt;\&lt;tfm&gt;\</c> layout AND the deeper
         /// per-project CI artifact layout — instead of hard-coding the walk-up depth. The old fixed
-        /// <c>\..\..\..</c> offset resolved to a non-existent path on CI, so every legacy test failed to
+        /// <c>\..\..\..</c> offset resolved to a nonexistent path on CI, so every legacy test failed to
         /// launch PowerToys there; this mirrors the .Next harness's resolver. When no ancestor holds the
         /// exe, it returns the historical fixed-depth path (made absolute) so a launch failure still names
         /// a concrete location.

--- a/src/modules/MeasureTool/Tests/ScreenRuler.UITests.Next/TestHelper.cs
+++ b/src/modules/MeasureTool/Tests/ScreenRuler.UITests.Next/TestHelper.cs
@@ -355,7 +355,7 @@ public static class TestHelper
     {
         ClearClipboard();
 
-        // Park the cursor on the primary-monitor centre so the Measure Tool initialises tracking at a
+        // Park the cursor on the primary-monitor centre so the Measure Tool initializes tracking at a
         // predictable on-screen spot before activation (the cursor can otherwise be anywhere).
         var (cx, cy) = ScreenCenter();
         MouseHelper.MoveTo(cx, cy);

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/AppStateModel.cs
@@ -21,7 +21,7 @@ public record AppStateModel
 
     // HERE BE DRAGONS: Using an ImmutableList<T> for a setting may explode in
     // AOT builds. Make sure to test IN AOT setting this setting to null, [],
-    // and and array with values.
+    // and an array with values.
     private ImmutableList<string>? _runHistory = ImmutableList<string>.Empty;
 
     public ImmutableList<string> RunHistory

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 public record SettingsModel
 {
-    // LOAD BEARNING: Some SettingsChanged subscribers react selectively (e.g.
+    // LOAD BEARING: Some SettingsChanged subscribers react selectively (e.g.
     // MainWindow.MainWindowSettingsComparer, DockWindowManager.OnSettingsChanged). If a new
     // setting needs a live reaction, add it there too - otherwise it won't take effect.
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/MainWindow.xaml.cs
@@ -500,7 +500,7 @@ public sealed partial class MainWindow : WindowEx,
     }
 
     /// <summary>
-    /// Returns true if the user has opted in to seeing the OS-drawn HWND chrome (an internal
+    /// Returns true if the user has opted into seeing the OS-drawn HWND chrome (an internal
     /// debugging setting). Always false in CI / release builds.
     /// </summary>
     private static bool ShouldShowHwndFrame(SettingsModel settings) =>
@@ -1679,7 +1679,7 @@ public sealed partial class MainWindow : WindowEx,
 
             // Borderless mode: claim the entire window rectangle as client area.
             // A resizable window has WS_THICKFRAME, which makes the OS reserve a
-            // non-client sizing frame *and* gives the window a DWM drop shadow / a thin
+            // non-client sizing frame *and* adds a DWM drop shadow / a thin
             // frame line along the top. We keep WS_THICKFRAME (so our custom WM_NCHITTEST
             // can still drive resizing) but tell the OS the whole window is client by
             // returning 0 from WM_NCCALCSIZE — which removes that frame and its shadow.

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockSettingsEqualityTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/DockSettingsEqualityTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 /// compare by <em>content</em> rather than by list reference. Dock consumers guard their
 /// (expensive) reloads with <c>_settings == args.DockSettings</c>, so two settings that differ
 /// only by having freshly-rebuilt band lists — e.g. after loading from disk — must compare
-/// equal, otherwise the reload fires needlessly.
+/// equal; otherwise the reload fires needlessly.
 /// </summary>
 [TestClass]
 public class DockSettingsEqualityTests

--- a/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
+++ b/src/modules/poweraccent/PowerAccent.UI/PowerAccentXAML/MainWindow.xaml.cs
@@ -36,7 +36,7 @@ public sealed partial class MainWindow : TransparentWindow, IDisposable
     {
         InitializeComponent();
 
-        // Give the overlay a stable UIA identity (window name) for accessibility tools (Narrator,
+        // Assign a stable UIA identity (window name) to the overlay for accessibility tools (Narrator,
         // Accessibility Insights) and the release-verification harness. "Quick Accent" is the
         // user-facing feature name.
         AppWindow.Title = "Quick Accent";


### PR DESCRIPTION
Pre-existing spelling issues in source files were surfaced by a large PR's whole-repo check-spelling scan. This fixes them at the root so main passes a full scan.

**Real typos (comments):**
- LOAD BEARNING -> LOAD BEARING
- initialises -> initializes (US spelling)
- nd and array -> nd an array

**Forbidden-pattern rewordings (comments):**
- opted in to -> opted into; gives the window a -> dds a
- Give the overlay a -> Assign ... to the overlay
- qual, otherwise -> qual; otherwise
- 
on-existent -> 
onexistent

**Dictionary (expect.txt):** genuine terms — Win32 hit-test constants (HTBOTTOM/HTLEFT/...), SETFOREGROUNDLOCKTIMEOUT, Miracast, Freelook, CABAC, GitHub Actions commands (logissue/endgroup), build vars, etc.

All changes are comments/strings/dictionary — no code behavior change.